### PR TITLE
update code to be compatible with Home Assistant 2025.1.0

### DIFF
--- a/custom_components/teleinformation/__init__.py
+++ b/custom_components/teleinformation/__init__.py
@@ -108,7 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     }
 
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
+        hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     )
 
     return True

--- a/custom_components/teleinformation/const.py
+++ b/custom_components/teleinformation/const.py
@@ -1,16 +1,14 @@
 from homeassistant.components.sensor import (
-    STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_TOTAL_INCREASING
-)
-from homeassistant.const import (
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_CURRENT,
-    ENERGY_WATT_HOUR,
-    POWER_VOLT_AMPERE,
-    ELECTRIC_CURRENT_AMPERE,
+    SensorStateClass,
+    SensorDeviceClass,
 )
 
+from homeassistant.const import (
+    UnitOfPower,
+    UnitOfApparentPower,
+    UnitOfEnergy,
+    UnitOfElectricCurrent,
+)
 
 DOMAIN = "teleinformation"
 
@@ -42,19 +40,19 @@ DATA_COORDINATOR = "coordinator"
 TYPE_ADDRESS = "ADCO"
 
 SENSOR_INDEX_ENERGY = {
-    "state_class": STATE_CLASS_TOTAL_INCREASING,
-    "native_unit_of_measurement": ENERGY_WATT_HOUR,
-    "device_class": DEVICE_CLASS_ENERGY,
+    "state_class": SensorStateClass.TOTAL_INCREASING,
+    "native_unit_of_measurement": UnitOfEnergy.WATT_HOUR,
+    "device_class": SensorDeviceClass.ENERGY,
 }
 SENSOR_APPARENT_POWER = {
-    "state_class": STATE_CLASS_MEASUREMENT,
-    "native_unit_of_measurement": POWER_VOLT_AMPERE,
-    "device_class": DEVICE_CLASS_POWER,
+    "state_class": SensorStateClass.MEASUREMENT,
+    "native_unit_of_measurement": UnitOfApparentPower.VOLT_AMPERE,
+    "device_class": SensorDeviceClass.APPARENT_POWER,
 }
 SENSOR_CURRENT = {
-    "state_class": STATE_CLASS_MEASUREMENT,
-    "native_unit_of_measurement": ELECTRIC_CURRENT_AMPERE,
-    "device_class": DEVICE_CLASS_CURRENT,
+    "state_class":SensorStateClass.MEASUREMENT,
+    "native_unit_of_measurement": UnitOfElectricCurrent.AMPERE,
+    "device_class": SensorDeviceClass.CURRENT,
 }
 SENSOR_DEFAULT = {}
 

--- a/custom_components/teleinformation/manifest.json
+++ b/custom_components/teleinformation/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "domain": "teleinformation",
   "name": "Télé-information",
   "config_flow": true,

--- a/custom_components/teleinformation/sensor.py
+++ b/custom_components/teleinformation/sensor.py
@@ -3,11 +3,12 @@ from homeassistant.components.sensor import (
     PLATFORM_SCHEMA, 
     SensorEntityDescription,
     SensorEntity,
+    SensorStateClass,
+    SensorDeviceClass,
 )
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
-    DEVICE_CLASS_CONNECTIVITY,
 )
 from homeassistant.config_entries import SOURCE_IMPORT
 import homeassistant.helpers.config_validation as cv
@@ -98,7 +99,7 @@ class LinkyEntity(BaseTeleInfoEntity, BinarySensorEntity):
         self.entity_description = BinarySensorEntityDescription(
             key=key,
             name=f"{self.basename} Meter",
-            device_class=DEVICE_CLASS_CONNECTIVITY
+            device_class=SensorDeviceClass
         )
 
     @property


### PR DESCRIPTION
In release 2025.1.0, some classes has been deprecated and must be replaced.
Also, async_forward_entry_setup must be replaced by async_forward_entry_setups to be compatible with 2025.6 (see https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/)